### PR TITLE
calculate subdomain offset based on APMSERVE_HOST

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const routers = networks.map(({ network, sub }) => {
   return subdomain(sub || `*.${network}`, apmRouter(network))
 })
 
+app.set("subdomain offset", process.env.APMSERVE_HOST.split('.').length)
 routers.forEach(router => app.use(router))
 
 // Error handler


### PR DESCRIPTION
need to support arbitrary length hosts like aragonpm.com and
aragonpm-test.aragon.network

Fixes #21