### PR TITLE
v0.6 release configuration

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ APMSERVE_APM=aragonpm.eth
 APMSERVE_ALIASES=[{"alias": "rinkeby.aragon.org", "target":"aragon.rinkeby"}, {"alias": "mainnet.aragon.org", "target":"aragon.mainnet"}]
 
 APMSERVE_IPFS=https://ipfs.eth.aragon.network/ipfs
-APMSERVE_NETWORKS=[{"network": "mainnet"}, {"network": "staging"}, {"network": "rinkeby-old"}, {"network": "rinkeby-new"}, {"network":"rinkeby", "sub": "*"}]
+APMSERVE_NETWORKS=[{"network": "mainnet"}, {"network": "staging"}, {"network": "rinkeby-old"}, {"network": "rinkeby-new"}, {"network":"rinkeby"}]
 
 APMSERVE_STAGING_ENS=0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939
 APMSERVE_STAGING_ETH=https://rinkeby.eth.aragon.network
@@ -12,10 +12,7 @@ APMSERVE_STAGING_ETH=https://rinkeby.eth.aragon.network
 APMSERVE_RINKEBY-OLD_ENS=0xfbAE32D1cDE62858bC45f51eFC8Cc4Fa1415447E
 APMSERVE_RINKEBY-OLD_ETH=https://rinkeby.eth.aragon.network
 
-APMSERVE_RINKEBY-NEW_ENS=0x98Df287B6C145399Aaa709692c8D308357bC085D
-APMSERVE_RINKEBY-NEW_ETH=https://rinkeby.eth.aragon.network
-
-APMSERVE_RINKEBY_ENS=0xfbAE32D1cDE62858bC45f51eFC8Cc4Fa1415447E
+APMSERVE_RINKEBY_ENS=0x98Df287B6C145399Aaa709692c8D308357bC085D
 APMSERVE_RINKEBY_ETH=https://rinkeby.eth.aragon.network
 
 APMSERVE_MAINNET_ENS=0x314159265dD8dbb310642f98f50C066173C1259b


### PR DESCRIPTION
- Removes Rinkeby as the default network, `[package].aragonpm.com` links will no longer work. A network always has to be specified: `[package].[network].aragonpm.com`.
- Points `*.rinkeby.aragonpm.com` to the new Rinkeby deployment. Old Rinkeby can still be accessed at `*.rinkeby-old.aragonpm.com`.